### PR TITLE
Connect Rails and React: Consume rails API endpoints 

### DIFF
--- a/src/components/Greeting.js
+++ b/src/components/Greeting.js
@@ -1,9 +1,16 @@
 import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { randomGreetings } from '../redux/greetings/actions/actions';
 
 const Greeting = () => {
+  const greetings = useSelector((state) => state.greetings);
+  const dispatch = useDispatch();
+
   return (
     <>
       <h1>Random Greetings</h1>
+      <p>{greetings}</p>
+      <button onClick={() => dispatch(randomGreetings())}>Click to greet</button>
     </>
   );
 };

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -1,0 +1,12 @@
+import { combineReducers, createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import logger from 'redux-logger';
+import greetingsReducer from './greetings/reducers/reducers';
+
+const rootReducer = combineReducers({
+  greetings: greetingsReducer,
+});
+
+const store = createStore(rootReducer, applyMiddleware(thunk, logger));
+
+export default store;

--- a/src/redux/greetings/actions/actions.js
+++ b/src/redux/greetings/actions/actions.js
@@ -1,0 +1,22 @@
+import GET_GREETINGS from '../actionsType/actionsType';
+const GET_GREETINGS_API = 'http://localhost:3000/api/greetings';
+
+export const getGreetings = async () => {
+  try {
+    const response = await fetch(`${GET_GREETINGS_API}`);
+    const data = await response.json();
+    return data;
+  } catch(err) {
+    return err;
+  }
+}
+
+export const randomGreetings = () => async (dispatch) => {
+  const result = await getGreetings();
+  return dispatch({
+    type: GET_GREETINGS,
+    payload: result.greeting,
+  });
+}
+
+export default randomGreetings;

--- a/src/redux/greetings/actionsType/actionsType.js
+++ b/src/redux/greetings/actionsType/actionsType.js
@@ -1,0 +1,3 @@
+const GET_GREETINGS = 'GET_GREETINGS';
+
+export default GET_GREETINGS;

--- a/src/redux/greetings/reducers/reducers.js
+++ b/src/redux/greetings/reducers/reducers.js
@@ -1,0 +1,15 @@
+import GET_GREETINGS from '../actionsType/actionsType';
+
+const initialState = [];
+
+const greetingsReducer = (state = initialState, action) => {
+  const { payload } = action;
+  switch(action.type) {
+    case GET_GREETINGS:
+      return payload;
+    default:
+      return state;
+  }
+}
+
+export default greetingsReducer;


### PR DESCRIPTION
In this pull request, I was able to:

- add route to the App.js component to interact with Greeting component
- add action and reducer to the hello-react-front-end app.
- consume API endpoints from rails back-end

# Back-end Link
[Back-end Link](https://github.com/Qoosim/hello-rails-back-end) 